### PR TITLE
Run CI on every push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 name: build
 
 on:
-  workflow_dispatch:
+  push:
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
 
   publish:
     needs: [package]
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
* Run CI on every push and pull request
* Only publish when a tag is pushed to avoid unnecessary commits, since build results can be downloaded from the CI run artifacts