### PR TITLE
Update deprecated build actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.7
         with:
           submodules: 'recursive' 
       - name: build
         run: ./ci/ci.bash
         shell: bash
       - name: upload-artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: godot-pure-data-${{ matrix.os }}
           path: work/install
@@ -32,16 +32,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.7
       - name: download all build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4.1.8
         with:
           path: work/artifacts
       - name: build
         run: sh ci/package.bash work/artifacts
         shell: bash
       - name: upload-artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: project
           path: addons
@@ -52,11 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.7
         with:
           ref: master
       - name: download all build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4.1.8
         with:
           name: project
           path: addons


### PR DESCRIPTION
Version 2 of the Github artifact actions was deprecated on 30 June 2024, so this updates the CI workflow to version 4 of those. This also should speed up workflow runs a bit, as they have made some efficiency improvements (although it isn't enough to really make a noticeable improvement).

[Link to the deprecation notice](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)