### PR TITLE
Fix MacOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ['ubuntu', 'windows']
+        os: ['ubuntu', 'windows', 'macos']
     runs-on: ${{ matrix.os }}-latest
     steps:
       - name: checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ project(gdnative-example)
 # options
 ###############################################################################
 
+# build universal binaries on macos
+if(APPLE)
+  set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "" FORCE)
+endif()
+
 ###############################################################################
 # libs
 ###############################################################################
@@ -49,12 +54,5 @@ set_target_properties(
   PROPERTIES
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED ON)
-
-if(APPLE)
-  set_target_properties(
-    pd-godot
-    PROPERTIES 
-    OSX_ARCHITECTURES "arm64;x86_64")
-endif()
 
 install(TARGETS pd-godot DESTINATION .)


### PR DESCRIPTION
This fixes a problem with how build architectures are set on MacOS that was causing libraries to only be built for the native architecture when building universal binaries. Builds still won't work until #3 is resolved, but once that is done MacOS builds should work properly.