### PR TITLE
Remove the remove old artifacts CI step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,13 +67,3 @@ jobs:
           git add -A
           git commit -am "automated commit"
           git push
-
-  remove-old-artifacts:
-    needs: [publish]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-    - name: remove-old-artifacts
-      uses: c-hive/gha-remove-artifacts@v1
-      with:
-        age: '10 minutes'


### PR DESCRIPTION
It throws an error and doesn't do anything, and Actions artifacts expire after a little while anyway. If there's a good reason to have it, I can try and fix whatever is causing it to fail (it probably just needs to be updated to a newer version), but I think it's better to just keep artifacts around so development builds can be accessed easier.