### PR TITLE
Update libpd

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/libpd"]
 	path = lib/libpd
-	url = git@github.com:samsface/libpd.git
+	url = git@github.com:libpd/libpd.git
 [submodule "lib/godot-cpp"]
 	path = lib/godot-cpp
 	url = git@github.com:godotengine/godot-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 # official site of the win pthread project
 if (MSVC)
   set(PTHREADS_LIB "${CMAKE_CURRENT_LIST_DIR}/lib/pthreads/lib/pthreadVC2.lib" CACHE PATH "..." FORCE)
-  set(PTHREADS_INCLUDE_DIR  "lib/pthreads/include" CACHE PATH "..." FORCE)
+  set(PTHREADS_INCLUDE_DIR  "${CMAKE_CURRENT_LIST_DIR}/lib/pthreads/include" CACHE PATH "..." FORCE)
 endif()
 
 add_subdirectory(lib/godot-cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,8 @@ endif()
 # libpd requires pthreads so using this windows port downloaded from the 
 # official site of the win pthread project
 if (MSVC)
-  set(CMAKE_THREAD_LIBS_INIT "${CMAKE_CURRENT_LIST_DIR}/lib/pthreads/lib/pthreadVC2.lib" CACHE PATH "..." FORCE)
+  set(PTHREADS_LIB "${CMAKE_CURRENT_LIST_DIR}/lib/pthreads/lib/pthreadVC2.lib" CACHE PATH "..." FORCE)
   set(PTHREADS_INCLUDE_DIR  "lib/pthreads/include" CACHE PATH "..." FORCE)
-  include_directories(${PTHREADS_INCLUDE_DIR})
 endif()
 
 add_subdirectory(lib/godot-cpp)


### PR DESCRIPTION
Updates libpd to upstream master. The problems with import paths have been fixed upstream so the fork is no longer needed and the library builds successfully for all platforms.